### PR TITLE
Exclude project root tasks from task counts

### DIFF
--- a/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
+++ b/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
@@ -48,7 +48,7 @@
                     const dct = x.constructor;
                     return Object.getOwnPropertyNames(dct)
                         .find(k => x === dct[k]);
-                }; 
+                };
 
                 const flattenedObjectsByStatus = parent => type => {
                     const tupleFromObj =
@@ -62,9 +62,21 @@
                         map(second(length)),
                         groupSort,
                         map(tupleFromObj),
-                        filter(o => !(o.constructor.name === 'Task' && o.project)) // exclude tasks which are a root task of a project
+                        filter(o =>
+                            o.constructor.name === "Task" &&
+                            !isRootTask(o)
+                        )
                     )(parent['flattened' + type + 's'])
                 }
+
+                // isRootTask :: OFTask -> Bool
+                const isRootTask = task => {
+                    const
+                        f = x => x.id.primaryKey;
+                    return f(task) === f(
+                        task.containingProject
+                    )
+                };
 
                 const inboxTasks = () => {
                     const xs = filter(x => x.inInbox)(

--- a/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
+++ b/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
@@ -63,20 +63,14 @@
                         groupSort,
                         map(tupleFromObj),
                         filter(o =>
-                            o.constructor.name === "Task" &&
-                            !isRootTask(o)
+                            !(o.constructor.name === "Task" &&
+                            isRootTask(o))
                         )
                     )(parent['flattened' + type + 's'])
                 }
 
                 // isRootTask :: OFTask -> Bool
-                const isRootTask = task => {
-                    const
-                        f = x => x.id.primaryKey;
-                    return f(task) === f(
-                        task.containingProject
-                    )
-                };
+                const isRootTask = task => Boolean(task.project)
 
                 // inboxTasks :: () -> [OFTask]
                 const inboxTasks = () => {

--- a/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
+++ b/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
@@ -78,6 +78,7 @@
                     )
                 };
 
+                // inboxTasks :: () -> [OFTask]
                 const inboxTasks = () => {
                     const xs = filter(x => x.inInbox)(
                         flattenedTasks

--- a/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
+++ b/OmniFocus 3 & 4/Statistics/OF Statistics.omnijs
@@ -61,7 +61,8 @@
                     return compose(
                         map(second(length)),
                         groupSort,
-                        map(tupleFromObj)
+                        map(tupleFromObj),
+                        filter(o => !(o.constructor.name === 'Task' && o.project)) // exclude tasks which are a root task of a project
                     )(parent['flattened' + type + 's'])
                 }
 


### PR DESCRIPTION
I love your Statistics plug-in which I use regularly. I made the following small change for my own use.

- Current: The task counts include the number of projects, because each project has a corresponding ‘root’ task.
- Change: I think it is clearer to include only actions and action groups in the task count. This avoids double-counting project items in the overall breakdown count. This is how OmniFocus does it when showing the number of actions at the top of the Projects perspective.